### PR TITLE
Neos 7.* support & Optional loading

### DIFF
--- a/Classes/Media/DuplicateInterceptor.php
+++ b/Classes/Media/DuplicateInterceptor.php
@@ -9,7 +9,7 @@ namespace Onedrop\ShortResourceUri\Media;
 
 use Neos\Error\Messages\Error;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Mvc\FlashMessageContainer;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageContainer;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Service\AssetService;

--- a/Classes/ResourceManagement/Target/FileSystemShortSymlinkTarget.php
+++ b/Classes/ResourceManagement/Target/FileSystemShortSymlinkTarget.php
@@ -18,7 +18,7 @@ class FileSystemShortSymlinkTarget extends FileSystemSymlinkTarget
     /**
      * {@inheritdoc}
      */
-    protected function getRelativePublicationPathAndFilename(ResourceMetaDataInterface $object)
+    protected function getRelativePublicationPathAndFilename(ResourceMetaDataInterface $object): string
     {
         if ($object->getRelativePublicationPath() !== '') {
             $pathAndFilename = $object->getRelativePublicationPath() . $object->getFilename();

--- a/Configuration/Settings.Resource.yaml
+++ b/Configuration/Settings.Resource.yaml
@@ -1,13 +1,15 @@
-Neos:
-  Flow:
-    resource:
-      targets:
-        localWebDirectoryShortUriPersistentResourcesTarget:
-          target: 'Onedrop\ShortResourceUri\ResourceManagement\Target\FileSystemShortSymlinkTarget'
-          targetOptions:
-            baseUri: '_media/'
-            path: '%FLOW_PATH_WEB%_media/'
-            relativeSymlinks: true
-      collections:
-        persistent:
-          target: 'localWebDirectoryShortUriPersistentResourcesTarget'
+# Add this configuration to settings to make this work
+#
+#Neos:
+#  Flow:
+#    resource:
+#      targets:
+#        localWebDirectoryShortUriPersistentResourcesTarget:
+#          target: 'Onedrop\ShortResourceUri\ResourceManagement\Target\FileSystemShortSymlinkTarget'
+#          targetOptions:
+#            baseUri: '_media/'
+#            path: '%FLOW_PATH_WEB%_media/'
+#            relativeSymlinks: true
+#      collections:
+#        persistent:
+#          target: 'localWebDirectoryShortUriPersistentResourcesTarget'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ storage.
 It will publish resources with a short uri like `/_media/alicecards.jpg` instead
 of the regular `/_Resources/Persistent/0d5f77e755f664b393b62ca51a056c06f05e83c6/alicecards.jpg`.
 
-It overrides the default publishing target for the `persistent` collection:
+It overrides the default publishing target for the `persistent` collection if you add the following configuration:
 ```yaml
 Neos:
   Flow:
@@ -21,6 +21,9 @@ Neos:
         persistent:
           target: 'localWebDirectoryShortUriPersistentResourcesTarget'
 ```
+
+Since v1.2.0 this must be added manually and is no longer default included. This way it is possible to
+for example only enable this in production context.
 
 ## Preventing duplicates
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "neos-package",
     "license": "MIT",
     "require": {
-        "neos/neos": ">=3.0 <5.0 || dev-master"
+        "neos/neos": "*"
     },
     "authors": [
         {


### PR DESCRIPTION
Optional loading to make it possible to load this only in Production context for example.

I needed this to be able to work with MagickWand (proxying the resources) on development, while wanting these shorter uri's in Production.

Since it is breaking behaviour I would tag it as minor.